### PR TITLE
removed the % sign at the beginning of sudo users content, so it woul…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,7 +73,7 @@ class profile_sudo  (
       default   => 'ALL=(ALL) NOPASSWD: ALL',
     }
     sudo::conf { "sudo for user ${user}":
-      content  => "%${user} ${snippet}",
+      content  => "${user} ${snippet}",
     }
     pam_access::entry { "Allow sudo for user ${user}":
       user       => $user,


### PR DESCRIPTION
This change was made so user sudo config would be read as user and not a group.

This branch was tested on mlong-agent1.